### PR TITLE
fix: inject version info into Docker image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,5 +82,9 @@ jobs:
           context: .
           push: false
           tags: ghcr.io/agjmills/trove:ci
+          build-args: |
+            VERSION=ci
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,3 +65,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,10 @@ RUN ./tailwindcss \
 # Stage 2: Build Go binary
 FROM golang:1.25-alpine AS builder
 
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_DATE=unknown
+
 RUN apk add --no-cache git ca-certificates tzdata
 
 WORKDIR /build
@@ -38,7 +42,7 @@ RUN go mod download
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build \
-    -ldflags="-s -w" \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
     -o trove \
     ./cmd/server
 


### PR DESCRIPTION
Fixes #74.

The `/health` endpoint was reporting `dev (commit: none, built: unknown)` on all Docker releases. The goreleaser binary builds get proper ldflags injected, but the Docker image was doing its own `go build` without them.

Added `VERSION`, `COMMIT`, and `BUILD_DATE` build args to the Dockerfile and wired them into the ldflags. The release workflow passes the tag name, commit SHA, and timestamp through. CI does the same with placeholder values so the arg path gets exercised on every PR.

Verified the strings are actually embedded in the binary before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to embed version, commit hash, and build date metadata into compiled binaries for improved traceability and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->