### PR TITLE
fix(shares): address coderabbit review feedback

### DIFF
--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -75,8 +75,8 @@ type ShareLink struct {
 	CreatedAt time.Time      `json:"created_at"`
 	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
 
-	File File `gorm:"foreignKey:FileID" json:"-"`
-	User User `gorm:"foreignKey:UserID" json:"-"`
+	File File `gorm:"foreignKey:FileID;constraint:OnDelete:CASCADE" json:"-"`
+	User User `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`
 }
 
 // UploadSession tracks state for resumable chunked uploads

--- a/internal/handlers/file_handler.go
+++ b/internal/handlers/file_handler.go
@@ -867,7 +867,7 @@ func (h *FileHandler) ViewFile(w http.ResponseWriter, r *http.Request) {
 
 	// Fetch active share links for this file
 	var shareLinks []models.ShareLink
-	h.db.Where("file_id = ? AND user_id = ?", file.ID, user.ID).Find(&shareLinks)
+	h.db.Where("file_id = ? AND user_id = ? AND (expires_at IS NULL OR expires_at > ?)", file.ID, user.ID, time.Now()).Find(&shareLinks)
 
 	// Render template
 	data := map[string]interface{}{

--- a/internal/handlers/share_handler.go
+++ b/internal/handlers/share_handler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -17,6 +16,8 @@ import (
 
 	"github.com/agjmills/trove/internal/auth"
 	"github.com/agjmills/trove/internal/database/models"
+	"github.com/agjmills/trove/internal/flash"
+	"github.com/agjmills/trove/internal/logger"
 	"github.com/agjmills/trove/internal/storage"
 )
 
@@ -101,6 +102,7 @@ func (h *ShareHandler) CreateShareLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	flash.Success(w, "Share link created.")
 	http.Redirect(w, r, "/files/"+strconv.FormatUint(fileID, 10), http.StatusSeeOther)
 }
 
@@ -183,6 +185,6 @@ func (h *ShareHandler) AccessShareLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if _, err := io.Copy(w, reader); err != nil {
-		log.Printf("Warning: error streaming shared file %s: %v", link.File.StoragePath, err)
+		logger.Error("error streaming shared file", "path", link.File.StoragePath, "error", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `OnDelete:CASCADE` to `ShareLink` File and User relations so share links are cleaned up when a file or user is permanently deleted
- Add flash success message after share link creation
- Replace `log.Printf` with structured logger for file streaming errors
- Filter expired share links from the file view query so users don't see links that no longer work

## Test plan
- [ ] Create a share link — confirm success toast appears
- [ ] Set an expiry on a share link — confirm it disappears from the file view after expiry
- [ ] Permanently delete a file — confirm associated share links are removed