### PR TITLE
feat(shares): password-protected share links

### DIFF
--- a/internal/database/models/models.go
+++ b/internal/database/models/models.go
@@ -65,15 +65,16 @@ type File struct {
 
 // ShareLink represents a public download link for a file
 type ShareLink struct {
-	ID        uint           `gorm:"primaryKey" json:"id"`
-	Token     string         `gorm:"uniqueIndex;not null;size:64" json:"token"`
-	FileID    uint           `gorm:"not null;index" json:"file_id"`
-	UserID    uint           `gorm:"not null;index" json:"user_id"`
-	ExpiresAt *time.Time     `gorm:"index" json:"expires_at,omitempty"` // nil = never expires
-	MaxUses   *int           `json:"max_uses,omitempty"`                // nil = unlimited
-	Uses      int            `gorm:"not null;default:0" json:"uses"`
-	CreatedAt time.Time      `json:"created_at"`
-	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	ID           uint           `gorm:"primaryKey" json:"id"`
+	Token        string         `gorm:"uniqueIndex;not null;size:64" json:"token"`
+	FileID       uint           `gorm:"not null;index" json:"file_id"`
+	UserID       uint           `gorm:"not null;index" json:"user_id"`
+	PasswordHash *string        `gorm:"size:255" json:"-"`                 // nil = no password
+	ExpiresAt    *time.Time     `gorm:"index" json:"expires_at,omitempty"` // nil = never expires
+	MaxUses      *int           `json:"max_uses,omitempty"`                // nil = unlimited
+	Uses         int            `gorm:"not null;default:0" json:"uses"`
+	CreatedAt    time.Time      `json:"created_at"`
+	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
 
 	File File `gorm:"foreignKey:FileID;constraint:OnDelete:CASCADE" json:"-"`
 	User User `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE" json:"-"`

--- a/internal/handlers/share_handler.go
+++ b/internal/handlers/share_handler.go
@@ -40,6 +40,72 @@ func generateToken() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
+// consumeUse atomically increments the use counter, respecting MaxUses.
+// Returns false if the limit has already been reached.
+func (h *ShareHandler) consumeUse(link *models.ShareLink) bool {
+	if link.MaxUses != nil {
+		result := h.db.Model(link).
+			Where("uses < ?", *link.MaxUses).
+			Update("uses", gorm.Expr("uses + 1"))
+		return result.Error == nil && result.RowsAffected > 0
+	}
+	h.db.Model(link).Update("uses", gorm.Expr("uses + 1")) //nolint:errcheck
+	return true
+}
+
+// streamFile writes the file contents to the response with appropriate headers.
+func (h *ShareHandler) streamFile(w http.ResponseWriter, r *http.Request, file models.File) {
+	reader, err := h.storage.Open(r.Context(), file.StoragePath)
+	if err != nil {
+		http.Error(w, "File not found", http.StatusNotFound)
+		return
+	}
+	defer reader.Close() //nolint:errcheck
+
+	safeFilename := strings.ReplaceAll(file.Filename, `"`, `\"`)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`,
+		safeFilename, url.PathEscape(file.Filename)))
+	w.Header().Set("Content-Type", file.MimeType)
+	if file.FileSize > 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(file.FileSize, 10))
+	}
+
+	if _, err := io.Copy(w, reader); err != nil {
+		logger.Error("error streaming shared file", "path", file.StoragePath, "error", err)
+	}
+}
+
+// showPasswordForm renders the password entry page for a protected share link.
+func (h *ShareHandler) showPasswordForm(w http.ResponseWriter, token, filename, errMsg string) {
+	if err := render(w, "share_password.html", map[string]any{
+		"Title":    "Protected Link",
+		"Token":    token,
+		"Filename": filename,
+		"Error":    errMsg,
+	}); err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+	}
+}
+
+// lookupValidLink fetches and validates a share link by token.
+// Writes a 404 response and returns nil if the token is invalid, expired, or the file is gone.
+func (h *ShareHandler) lookupValidLink(w http.ResponseWriter, token string) *models.ShareLink {
+	var link models.ShareLink
+	if err := h.db.Preload("File").Where("token = ?", token).First(&link).Error; err != nil {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+		return nil
+	}
+	if link.ExpiresAt != nil && time.Now().After(*link.ExpiresAt) {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+		return nil
+	}
+	if link.File.ID == 0 || link.File.SoftDeletedAt != nil {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+		return nil
+	}
+	return &link
+}
+
 // CreateShareLink handles POST /files/{id}/share.
 // Creates a new share link for a file owned by the authenticated user.
 func (h *ShareHandler) CreateShareLink(w http.ResponseWriter, r *http.Request) {
@@ -84,6 +150,16 @@ func (h *ShareHandler) CreateShareLink(w http.ResponseWriter, r *http.Request) {
 		maxUses = &n
 	}
 
+	var passwordHash *string
+	if v := r.FormValue("password"); v != "" {
+		h, err := auth.HashPassword(v, 10)
+		if err != nil {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		passwordHash = &h
+	}
+
 	token, err := generateToken()
 	if err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -91,11 +167,12 @@ func (h *ShareHandler) CreateShareLink(w http.ResponseWriter, r *http.Request) {
 	}
 
 	link := models.ShareLink{
-		Token:     token,
-		FileID:    uint(fileID),
-		UserID:    user.ID,
-		ExpiresAt: expiresAt,
-		MaxUses:   maxUses,
+		Token:        token,
+		FileID:       uint(fileID),
+		UserID:       user.ID,
+		ExpiresAt:    expiresAt,
+		MaxUses:      maxUses,
+		PasswordHash: passwordHash,
 	}
 	if err := h.db.Create(&link).Error; err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -134,57 +211,53 @@ func (h *ShareHandler) RevokeShareLink(w http.ResponseWriter, r *http.Request) {
 // AccessShareLink handles GET /s/{token}.
 // Public endpoint — no authentication required.
 // Returns 404 for expired, exhausted, revoked, or non-existent tokens (no enumeration).
+// If the link is password-protected, renders a password entry form instead of serving the file.
 func (h *ShareHandler) AccessShareLink(w http.ResponseWriter, r *http.Request) {
 	token := chi.URLParam(r, "token")
+	link := h.lookupValidLink(w, token)
+	if link == nil {
+		return
+	}
 
-	var link models.ShareLink
-	err := h.db.Preload("File").Where("token = ?", token).First(&link).Error
-	if err != nil {
+	// Password-protected: show form, do not consume a use yet.
+	if link.PasswordHash != nil {
+		h.showPasswordForm(w, token, link.File.Filename, "")
+		return
+	}
+
+	if !h.consumeUse(link) {
 		http.NotFound(w, r)
 		return
 	}
 
-	// Check expiry
-	if link.ExpiresAt != nil && time.Now().After(*link.ExpiresAt) {
+	h.streamFile(w, r, link.File)
+}
+
+// VerifySharePassword handles POST /s/{token}.
+// Validates the submitted password and, if correct, streams the file.
+func (h *ShareHandler) VerifySharePassword(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	link := h.lookupValidLink(w, token)
+	if link == nil {
+		return
+	}
+
+	// No password required — redirect to GET which will serve directly.
+	if link.PasswordHash == nil {
+		http.Redirect(w, r, "/s/"+token, http.StatusSeeOther)
+		return
+	}
+
+	password := r.FormValue("password")
+	if !auth.VerifyPassword(*link.PasswordHash, password) {
+		h.showPasswordForm(w, token, link.File.Filename, "Incorrect password. Please try again.")
+		return
+	}
+
+	if !h.consumeUse(link) {
 		http.NotFound(w, r)
 		return
 	}
 
-	// Ensure the file hasn't been trashed or hard-deleted before consuming a use
-	if link.File.ID == 0 || link.File.SoftDeletedAt != nil {
-		http.NotFound(w, r)
-		return
-	}
-
-	// Check max uses and increment atomically
-	if link.MaxUses != nil {
-		updated := h.db.Model(&link).
-			Where("uses < ?", *link.MaxUses).
-			Update("uses", gorm.Expr("uses + 1"))
-		if updated.Error != nil || updated.RowsAffected == 0 {
-			http.NotFound(w, r)
-			return
-		}
-	} else {
-		h.db.Model(&link).Update("uses", gorm.Expr("uses + 1")) //nolint:errcheck
-	}
-
-	reader, err := h.storage.Open(r.Context(), link.File.StoragePath)
-	if err != nil {
-		http.Error(w, "File not found", http.StatusNotFound)
-		return
-	}
-	defer reader.Close() //nolint:errcheck
-
-	safeFilename := strings.ReplaceAll(link.File.Filename, `"`, `\"`)
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`,
-		safeFilename, url.PathEscape(link.File.Filename)))
-	w.Header().Set("Content-Type", link.File.MimeType)
-	if link.File.FileSize > 0 {
-		w.Header().Set("Content-Length", strconv.FormatInt(link.File.FileSize, 10))
-	}
-
-	if _, err := io.Copy(w, reader); err != nil {
-		logger.Error("error streaming shared file", "path", link.File.StoragePath, "error", err)
-	}
+	h.streamFile(w, r, link.File)
 }

--- a/internal/handlers/share_handler_test.go
+++ b/internal/handlers/share_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 
+	"github.com/agjmills/trove/internal/auth"
 	"github.com/agjmills/trove/internal/database/models"
 )
 
@@ -193,6 +194,11 @@ func TestCreateShareLink_Unauthenticated(t *testing.T) {
 
 func createShareLink(t *testing.T, db *gorm.DB, fileID, userID uint, expiresAt *time.Time, maxUses *int) *models.ShareLink {
 	t.Helper()
+	return createShareLinkWithPassword(t, db, fileID, userID, expiresAt, maxUses, "")
+}
+
+func createShareLinkWithPassword(t *testing.T, db *gorm.DB, fileID, userID uint, expiresAt *time.Time, maxUses *int, password string) *models.ShareLink {
+	t.Helper()
 	token, err := generateToken()
 	if err != nil {
 		t.Fatalf("generateToken: %v", err)
@@ -204,8 +210,28 @@ func createShareLink(t *testing.T, db *gorm.DB, fileID, userID uint, expiresAt *
 		ExpiresAt: expiresAt,
 		MaxUses:   maxUses,
 	}
+	if password != "" {
+		h, err := auth.HashPassword(password, 4) // bcrypt.MinCost for test speed
+		if err != nil {
+			t.Fatalf("HashPassword: %v", err)
+		}
+		link.PasswordHash = &h
+	}
 	db.Create(link)
 	return link
+}
+
+func makeVerifyRequest(t *testing.T, h *ShareHandler, token, password string) *httptest.ResponseRecorder {
+	t.Helper()
+	body := "password=" + password
+	req := httptest.NewRequest(http.MethodPost, "/s/"+token, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("token", token)
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	w := httptest.NewRecorder()
+	h.VerifySharePassword(w, req)
+	return w
 }
 
 func makeAccessRequest(t *testing.T, h *ShareHandler, token string) *httptest.ResponseRecorder {
@@ -330,5 +356,116 @@ func TestRevokeShareLink_WrongOwner(t *testing.T) {
 	w2 := makeAccessRequest(t, h, link.Token)
 	if w2.Code != http.StatusOK {
 		t.Errorf("link should still be valid, got %d", w2.Code)
+	}
+}
+
+// --- Password-protected share links ---
+
+func TestCreateShareLink_WithPassword(t *testing.T) {
+	h, db, user := setupShareTest(t)
+	file := createTestFile(t, db, user.ID)
+
+	w := makeShareRequest(t, h, user, fmt.Sprint(file.ID), "password=secret123")
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("want 303, got %d", w.Code)
+	}
+
+	var link models.ShareLink
+	db.Where("file_id = ?", file.ID).First(&link)
+	if link.PasswordHash == nil {
+		t.Fatal("PasswordHash should be set")
+	}
+	if auth.VerifyPassword(*link.PasswordHash, "secret123") == false {
+		t.Error("PasswordHash should verify against the submitted password")
+	}
+}
+
+func TestAccessShareLink_PasswordProtected_ShowsForm(t *testing.T) {
+	h, db, user := setupShareTest(t)
+	file := createTestFile(t, db, user.ID)
+	link := createShareLinkWithPassword(t, db, file.ID, user.ID, nil, nil, "secret")
+
+	w := makeAccessRequest(t, h, link.Token)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 (password form), got %d", w.Code)
+	}
+	// Should return HTML, not the file contents
+	if w.Body.String() == "hello" {
+		t.Error("should not serve file without password")
+	}
+	// Uses counter should NOT be incremented
+	var updated models.ShareLink
+	db.First(&updated, link.ID)
+	if updated.Uses != 0 {
+		t.Errorf("uses should not be incremented for GET on protected link, got %d", updated.Uses)
+	}
+}
+
+func TestVerifySharePassword_WrongPassword(t *testing.T) {
+	h, db, user := setupShareTest(t)
+	file := createTestFile(t, db, user.ID)
+	link := createShareLinkWithPassword(t, db, file.ID, user.ID, nil, nil, "correct")
+
+	w := makeVerifyRequest(t, h, link.Token, "wrong")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 (form with error), got %d", w.Code)
+	}
+	if w.Body.String() == "hello" {
+		t.Error("should not serve file with wrong password")
+	}
+	var updated models.ShareLink
+	db.First(&updated, link.ID)
+	if updated.Uses != 0 {
+		t.Errorf("uses should not increment on wrong password, got %d", updated.Uses)
+	}
+}
+
+func TestVerifySharePassword_CorrectPassword(t *testing.T) {
+	h, db, user := setupShareTest(t)
+	file := createTestFile(t, db, user.ID)
+	link := createShareLinkWithPassword(t, db, file.ID, user.ID, nil, nil, "correct")
+
+	w := makeVerifyRequest(t, h, link.Token, "correct")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 (file), got %d: %s", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "hello" {
+		t.Errorf("want file contents, got %q", w.Body.String())
+	}
+	var updated models.ShareLink
+	db.First(&updated, link.ID)
+	if updated.Uses != 1 {
+		t.Errorf("want uses=1 after correct password, got %d", updated.Uses)
+	}
+}
+
+func TestVerifySharePassword_MaxUsesRespected(t *testing.T) {
+	h, db, user := setupShareTest(t)
+	file := createTestFile(t, db, user.ID)
+	maxUses := 1
+	link := createShareLinkWithPassword(t, db, file.ID, user.ID, nil, &maxUses, "pw")
+
+	// First correct attempt should succeed
+	w := makeVerifyRequest(t, h, link.Token, "pw")
+	if w.Code != http.StatusOK || w.Body.String() != "hello" {
+		t.Fatalf("first access should succeed, got %d %q", w.Code, w.Body.String())
+	}
+
+	// Second attempt should be blocked even with correct password
+	w2 := makeVerifyRequest(t, h, link.Token, "pw")
+	if w2.Code != http.StatusNotFound {
+		t.Errorf("want 404 after max uses exhausted, got %d", w2.Code)
+	}
+}
+
+func TestVerifySharePassword_NoPasswordRedirects(t *testing.T) {
+	h, db, user := setupShareTest(t)
+	file := createTestFile(t, db, user.ID)
+	link := createShareLink(t, db, file.ID, user.ID, nil, nil)
+
+	// POST to a non-password link should redirect to GET
+	w := makeVerifyRequest(t, h, link.Token, "")
+	if w.Code != http.StatusSeeOther {
+		t.Errorf("want 303 redirect for non-password link, got %d", w.Code)
 	}
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -184,6 +184,7 @@ func Setup(r chi.Router, db *gorm.DB, cfg *config.Config, storageService storage
 
 	// Public share link access — no authentication required
 	r.Get("/s/{token}", shareHandler.AccessShareLink)
+	r.Post("/s/{token}", shareHandler.VerifySharePassword)
 
 	fileServer := http.FileServer(http.Dir("web/static"))
 	r.Handle("/static/*", http.StripPrefix("/static/", fileServer))

--- a/web/templates/file_view.html
+++ b/web/templates/file_view.html
@@ -181,6 +181,10 @@
 								{{if .ExpiresAt}}<span>Expires {{.ExpiresAt.Format "Jan 2, 2006"}}</span>{{else}}<span>No expiry</span>{{end}}
 								{{if .MaxUses}}<span>{{.Uses}}/{{deref .MaxUses}} uses</span>{{else}}<span>{{.Uses}} uses</span>{{end}}
 								<span>Created {{.CreatedAt.Format "Jan 2, 2006"}}</span>
+								{{if .PasswordHash}}<span class="flex items-center gap-1 text-gray-600 dark:text-gray-300">
+									<svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path></svg>
+									Password protected
+								</span>{{end}}
 							</div>
 						</div>
 						<form method="POST" action="/share/{{.Token}}/revoke" class="shrink-0">
@@ -209,6 +213,11 @@
 							<div class="flex-1">
 								<label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Max uses (optional)</label>
 								<input type="number" name="max_uses" min="1" placeholder="Unlimited"
+									class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500">
+							</div>
+							<div class="flex-1">
+								<label class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Password (optional)</label>
+								<input type="password" name="password" placeholder="No password"
 									class="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500">
 							</div>
 						</div>

--- a/web/templates/share_password.html
+++ b/web/templates/share_password.html
@@ -1,0 +1,45 @@
+{{define "content"}}
+<div class="min-h-[80vh] flex items-center justify-center py-12 px-4">
+	<div class="w-full max-w-sm">
+		<div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-8">
+			<div class="text-center mb-6">
+				<div class="flex justify-center mb-4">
+					<div class="w-14 h-14 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
+						<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-gray-600 dark:text-gray-300" aria-hidden="true">
+							<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+							<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+						</svg>
+					</div>
+				</div>
+				<h1 class="text-xl font-semibold text-gray-900 dark:text-gray-100">Password Protected</h1>
+				{{if .Filename}}
+				<p class="text-sm text-gray-500 dark:text-gray-400 mt-1 truncate" title="{{.Filename}}">{{.Filename}}</p>
+				{{else}}
+				<p class="text-sm text-gray-500 dark:text-gray-400 mt-1">This link requires a password to access.</p>
+				{{end}}
+			</div>
+
+			{{if .Error}}
+			<div class="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+				<p class="text-sm text-red-700 dark:text-red-400">{{.Error}}</p>
+			</div>
+			{{end}}
+
+			<form method="POST" action="/s/{{.Token}}">
+				<div class="mb-4">
+					<label for="password" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Password</label>
+					<input type="password" id="password" name="password" autofocus required
+						class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-400">
+				</div>
+				<button type="submit"
+					class="w-full flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium text-white bg-gray-900 dark:bg-gray-600 hover:bg-gray-700 dark:hover:bg-gray-500 rounded-lg transition-colors">
+					<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+						<path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"></path>
+					</svg>
+					Access File
+				</button>
+			</form>
+		</div>
+	</div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary

- Add optional `password` field to the share link creation form
- Password is bcrypt-hashed and stored on the `ShareLink` model (`PasswordHash *string`)
- Protected links render a password entry form (`share_password.html`) instead of immediately serving the file
- Wrong password re-renders the form with an error message; use count is only consumed on successful access
- Lock badge shown on the file view page for password-protected links

## Test plan

- [x] Unit tests: `TestCreateShareLink_WithPassword`, `TestAccessShareLink_PasswordProtected_ShowsForm`, `TestVerifySharePassword_WrongPassword`, `TestVerifySharePassword_CorrectPassword`, `TestVerifySharePassword_MaxUsesRespected`, `TestVerifySharePassword_NoPasswordRedirects`
- [x] Playwright browser test: wrong password shows error, correct password downloads file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share links can now be password-protected; password is optional when creating a link.
  * Password-protected links prompt for password verification before granting access; use counters only increment after successful password entry.
  * Admins are now prompted for confirmation when attempting to change their own identity provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->