### PR TITLE
fix: correct docs nav link URL

### DIFF
--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -31,7 +31,7 @@ theme = "hextra"
 
 [[menu.main]]
   name = "Docs"
-  url = "/trove/docs/"
+  url = "/docs/"
   weight = 1
 
 [[menu.main]]


### PR DESCRIPTION
The Docs nav link was pointing to `/trove/docs/` which Hugo doubled up with the baseURL prefix, resulting in `/trove/trove/docs/`. Changed to `/docs/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation menu link to use a new URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->