### PR TITLE
feat: add file sorting by filename, size, created_at with URL persist…

### DIFF
--- a/internal/handlers/page_handler.go
+++ b/internal/handlers/page_handler.go
@@ -195,8 +195,8 @@ func (h *PageHandler) ShowFiles(w http.ResponseWriter, r *http.Request) {
 
 	if dbOrderColumn == "original_filename" {
 		sort.Slice(allFiles, func(i, j int) bool {
-			nameI := strings.ToLower(allFiles[i].OriginalFilename)
-			nameJ := strings.ToLower(allFiles[j].OriginalFilename)
+			nameI := strings.ToLower(allFiles[i].Filename)
+			nameJ := strings.ToLower(allFiles[j].Filename)
 
 			if sortOrder == "desc" {
 				return natural.Less(nameJ, nameI)

--- a/internal/handlers/page_handler.go
+++ b/internal/handlers/page_handler.go
@@ -60,13 +60,34 @@ func (h *PageHandler) ShowFiles(w http.ResponseWriter, r *http.Request) {
 	}
 	offset := (page - 1) * pageSize
 
+	sortField := r.URL.Query().Get("sort")
+	sortOrder := strings.ToLower(r.URL.Query().Get("order"))
+
+	if sortOrder != "asc" && sortOrder != "desc" {
+		sortOrder = "asc"
+	}
+
+	allowedSorts := map[string]string{
+		"filename":   "original_filename",
+		"file_size":  "file_size",
+		"created_at": "created_at",
+	}
+
+	dbOrderColumn, ok := allowedSorts[sortField]
+	if !ok {
+		dbOrderColumn = "original_filename"
+		sortField = "filename"
+	}
+
+	orderExpression := dbOrderColumn + " " + strings.ToUpper(sortOrder)
+
 	// Get direct subfolders from Folders table (exclude deleted)
 	var folders []models.Folder
 	if currentFolder == "/" {
 		// Root level: get folders that don't contain additional slashes after the first one
 		h.db.Raw(`
-			SELECT * FROM folders 
-			WHERE user_id = ? 
+			SELECT * FROM folders
+			WHERE user_id = ?
 			AND folder_path LIKE '/%'
 			AND folder_path NOT LIKE '%/%/%'
 			AND LENGTH(folder_path) - LENGTH(REPLACE(folder_path, '/', '')) = 1
@@ -77,8 +98,8 @@ func (h *PageHandler) ShowFiles(w http.ResponseWriter, r *http.Request) {
 	} else {
 		// Subdirectory: get direct children only
 		h.db.Raw(`
-			SELECT * FROM folders 
-			WHERE user_id = ? 
+			SELECT * FROM folders
+			WHERE user_id = ?
 			AND folder_path LIKE ?
 			AND folder_path NOT LIKE ?
 			AND deleted_at IS NULL
@@ -160,21 +181,35 @@ func (h *PageHandler) ShowFiles(w http.ResponseWriter, r *http.Request) {
 	// Exclude failed uploads - they are shown as toast notifications instead
 	// Exclude deleted files
 	var allFiles []models.File
-	h.db.Where("user_id = ? AND logical_path = ? AND upload_status != ? AND trashed_at IS NULL", user.ID, currentFolder, "failed").Find(&allFiles)
 
-	// Sort files naturally (handles "file2" before "file10" correctly)
-	sort.Slice(allFiles, func(i, j int) bool {
-		return natural.Less(strings.ToLower(allFiles[i].OriginalFilename), strings.ToLower(allFiles[j].OriginalFilename))
-	})
+	query := h.db.Where("user_id = ? AND logical_path = ? AND upload_status != ? AND trashed_at IS NULL",
+		user.ID, currentFolder, "failed")
+
+	query = query.Order(orderExpression)
+
+	if dbOrderColumn == "original_filename" {
+		query = query.Order("created_at ASC") // or "id ASC" for stability
+	}
+
+	query.Find(&allFiles)
+
+	if dbOrderColumn == "original_filename" {
+		sort.Slice(allFiles, func(i, j int) bool {
+			nameI := strings.ToLower(allFiles[i].OriginalFilename)
+			nameJ := strings.ToLower(allFiles[j].OriginalFilename)
+
+			if sortOrder == "desc" {
+				return natural.Less(nameJ, nameI)
+			}
+			return natural.Less(nameI, nameJ)
+		})
+	}
 
 	// Pagination applies only to files (folders are always shown)
 	totalFiles := len(allFiles)
 	var files []models.File
 	if offset < totalFiles {
-		end := offset + pageSize
-		if end > totalFiles {
-			end = totalFiles
-		}
+		end := min(offset+pageSize, totalFiles)
 		files = allFiles[offset:end]
 	}
 
@@ -225,7 +260,7 @@ func (h *PageHandler) ShowFiles(w http.ResponseWriter, r *http.Request) {
 	// Count deleted items for nav badge (single query for both files and folders)
 	var deletedCount int64
 	h.db.Raw(`
-		SELECT 
+		SELECT
 			(SELECT COUNT(*) FROM files WHERE user_id = ? AND trashed_at IS NOT NULL AND deleted_at IS NULL) +
 			(SELECT COUNT(*) FROM folders WHERE user_id = ? AND trashed_at IS NOT NULL AND deleted_at IS NULL) AS total
 	`, user.ID, user.ID).Scan(&deletedCount)
@@ -246,6 +281,8 @@ func (h *PageHandler) ShowFiles(w http.ResponseWriter, r *http.Request) {
 		"MaxUploadSize": h.cfg.MaxUploadSize,
 		"FailedUploads": failedUploads,
 		"DeletedCount":  deletedCount,
+		"SortField":     sortField,
+		"SortOrder":     sortOrder,
 	}); err != nil {
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	}

--- a/internal/handlers/page_handler_test.go
+++ b/internal/handlers/page_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	csrf "filippo.io/csrf/gorilla"
 	"github.com/maruel/natural"
@@ -234,5 +235,131 @@ func TestFilesOnlyPagination(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func parseTime(s string) time.Time {
+	t, _ := time.Parse("2006-01-02", s)
+	return t
+}
+
+func TestFileSorting(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     []models.File
+		sortField string
+		sortOrder string
+		expected  []string
+	}{
+		{
+			name: "natural sort by name ASC",
+			files: []models.File{
+				{OriginalFilename: "file10.txt"},
+				{OriginalFilename: "file2.txt"},
+				{OriginalFilename: "File20.txt"},
+				{OriginalFilename: "file1.txt"},
+				{OriginalFilename: "file3.txt"},
+				{OriginalFilename: "image2.png"},
+				{OriginalFilename: "image10.png"},
+			},
+			sortField: "original_filename",
+			sortOrder: "ASC",
+			expected:  []string{"file1.txt", "file2.txt", "file3.txt", "file10.txt", "File20.txt", "image2.png", "image10.png"},
+		},
+		{
+			name: "natural sort by name DESC",
+			files: []models.File{
+				{OriginalFilename: "file10.txt"},
+				{OriginalFilename: "file2.txt"},
+				{OriginalFilename: "File20.txt"},
+				{OriginalFilename: "file1.txt"},
+				{OriginalFilename: "file3.txt"},
+			},
+			sortField: "original_filename",
+			sortOrder: "DESC",
+			expected:  []string{"File20.txt", "file10.txt", "file3.txt", "file2.txt", "file1.txt"},
+		},
+		{
+			name: "sort by size ASC",
+			files: []models.File{
+				{OriginalFilename: "small.txt", FileSize: 100},
+				{OriginalFilename: "large.txt", FileSize: 5000},
+				{OriginalFilename: "medium.txt", FileSize: 500},
+			},
+			sortField: "file_size",
+			sortOrder: "ASC",
+			expected:  []string{"small.txt", "medium.txt", "large.txt"},
+		},
+		{
+			name: "sort by size DESC",
+			files: []models.File{
+				{OriginalFilename: "small.txt", FileSize: 100},
+				{OriginalFilename: "large.txt", FileSize: 5000},
+				{OriginalFilename: "medium.txt", FileSize: 500},
+			},
+			sortField: "file_size",
+			sortOrder: "DESC",
+			expected:  []string{"large.txt", "medium.txt", "small.txt"},
+		},
+		{
+			name: "sort by date ASC",
+			files: []models.File{
+				{OriginalFilename: "newest.txt", CreatedAt: parseTime("2026-04-08")},
+				{OriginalFilename: "oldest.txt", CreatedAt: parseTime("2025-01-01")},
+				{OriginalFilename: "middle.txt", CreatedAt: parseTime("2025-12-01")},
+			},
+			sortField: "created_at",
+			sortOrder: "ASC",
+			expected:  []string{"oldest.txt", "middle.txt", "newest.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := make([]models.File, len(tt.files))
+			copy(files, tt.files)
+
+			if tt.sortField == "original_filename" {
+				sort.Slice(files, func(i, j int) bool {
+					nameI := strings.ToLower(files[i].OriginalFilename)
+					nameJ := strings.ToLower(files[j].OriginalFilename)
+
+					if tt.sortOrder == "DESC" {
+						return natural.Less(nameJ, nameI)
+					}
+					return natural.Less(nameI, nameJ)
+				})
+			} else {
+				sort.Slice(files, func(i, j int) bool {
+					var less bool
+					switch tt.sortField {
+					case "file_size":
+						less = files[i].FileSize < files[j].FileSize
+					case "created_at":
+						less = files[i].CreatedAt.Before(files[j].CreatedAt)
+					}
+
+					if tt.sortOrder == "DESC" {
+						return !less
+					}
+					return less
+				})
+			}
+
+			got := make([]string, len(files))
+			for i, f := range files {
+				got[i] = f.OriginalFilename
+			}
+
+			if len(got) != len(tt.expected) {
+				t.Fatalf("length mismatch: got %d, want %d", len(got), len(tt.expected))
+			}
+
+			for i := range got {
+				if got[i] != tt.expected[i] {
+					t.Errorf("position %d: got %s, want %s", i, got[i], tt.expected[i])
+				}
+			}
+		})
 	}
 }

--- a/internal/handlers/page_handler_test.go
+++ b/internal/handlers/page_handler_test.go
@@ -254,62 +254,62 @@ func TestFileSorting(t *testing.T) {
 		{
 			name: "natural sort by name ASC",
 			files: []models.File{
-				{OriginalFilename: "file10.txt"},
-				{OriginalFilename: "file2.txt"},
-				{OriginalFilename: "File20.txt"},
-				{OriginalFilename: "file1.txt"},
-				{OriginalFilename: "file3.txt"},
-				{OriginalFilename: "image2.png"},
-				{OriginalFilename: "image10.png"},
+				{Filename: "file10.txt"},
+				{Filename: "file2.txt"},
+				{Filename: "File20.txt"},
+				{Filename: "file1.txt"},
+				{Filename: "file3.txt"},
+				{Filename: "image2.png"},
+				{Filename: "image10.png"},
 			},
-			sortField: "original_filename",
-			sortOrder: "ASC",
+			sortField: "filename",
+			sortOrder: "asc",
 			expected:  []string{"file1.txt", "file2.txt", "file3.txt", "file10.txt", "File20.txt", "image2.png", "image10.png"},
 		},
 		{
 			name: "natural sort by name DESC",
 			files: []models.File{
-				{OriginalFilename: "file10.txt"},
-				{OriginalFilename: "file2.txt"},
-				{OriginalFilename: "File20.txt"},
-				{OriginalFilename: "file1.txt"},
-				{OriginalFilename: "file3.txt"},
+				{Filename: "file10.txt"},
+				{Filename: "file2.txt"},
+				{Filename: "File20.txt"},
+				{Filename: "file1.txt"},
+				{Filename: "file3.txt"},
 			},
-			sortField: "original_filename",
-			sortOrder: "DESC",
+			sortField: "filename",
+			sortOrder: "desc",
 			expected:  []string{"File20.txt", "file10.txt", "file3.txt", "file2.txt", "file1.txt"},
 		},
 		{
 			name: "sort by size ASC",
 			files: []models.File{
-				{OriginalFilename: "small.txt", FileSize: 100},
-				{OriginalFilename: "large.txt", FileSize: 5000},
-				{OriginalFilename: "medium.txt", FileSize: 500},
+				{Filename: "small.txt", FileSize: 100},
+				{Filename: "large.txt", FileSize: 5000},
+				{Filename: "medium.txt", FileSize: 500},
 			},
 			sortField: "file_size",
-			sortOrder: "ASC",
+			sortOrder: "asc",
 			expected:  []string{"small.txt", "medium.txt", "large.txt"},
 		},
 		{
 			name: "sort by size DESC",
 			files: []models.File{
-				{OriginalFilename: "small.txt", FileSize: 100},
-				{OriginalFilename: "large.txt", FileSize: 5000},
-				{OriginalFilename: "medium.txt", FileSize: 500},
+				{Filename: "small.txt", FileSize: 100},
+				{Filename: "large.txt", FileSize: 5000},
+				{Filename: "medium.txt", FileSize: 500},
 			},
 			sortField: "file_size",
-			sortOrder: "DESC",
+			sortOrder: "desc",
 			expected:  []string{"large.txt", "medium.txt", "small.txt"},
 		},
 		{
 			name: "sort by date ASC",
 			files: []models.File{
-				{OriginalFilename: "newest.txt", CreatedAt: parseTime("2026-04-08")},
-				{OriginalFilename: "oldest.txt", CreatedAt: parseTime("2025-01-01")},
-				{OriginalFilename: "middle.txt", CreatedAt: parseTime("2025-12-01")},
+				{Filename: "newest.txt", CreatedAt: parseTime("2026-04-08")},
+				{Filename: "oldest.txt", CreatedAt: parseTime("2025-01-01")},
+				{Filename: "middle.txt", CreatedAt: parseTime("2025-12-01")},
 			},
 			sortField: "created_at",
-			sortOrder: "ASC",
+			sortOrder: "asc",
 			expected:  []string{"oldest.txt", "middle.txt", "newest.txt"},
 		},
 	}
@@ -319,12 +319,12 @@ func TestFileSorting(t *testing.T) {
 			files := make([]models.File, len(tt.files))
 			copy(files, tt.files)
 
-			if tt.sortField == "original_filename" {
+			if tt.sortField == "filename" {
 				sort.Slice(files, func(i, j int) bool {
-					nameI := strings.ToLower(files[i].OriginalFilename)
-					nameJ := strings.ToLower(files[j].OriginalFilename)
+					nameI := strings.ToLower(files[i].Filename)
+					nameJ := strings.ToLower(files[j].Filename)
 
-					if tt.sortOrder == "DESC" {
+					if tt.sortOrder == "desc" {
 						return natural.Less(nameJ, nameI)
 					}
 					return natural.Less(nameI, nameJ)
@@ -339,7 +339,7 @@ func TestFileSorting(t *testing.T) {
 						less = files[i].CreatedAt.Before(files[j].CreatedAt)
 					}
 
-					if tt.sortOrder == "DESC" {
+					if tt.sortOrder == "desc" {
 						return !less
 					}
 					return less
@@ -348,7 +348,7 @@ func TestFileSorting(t *testing.T) {
 
 			got := make([]string, len(files))
 			for i, f := range files {
-				got[i] = f.OriginalFilename
+				got[i] = f.Filename
 			}
 
 			if len(got) != len(tt.expected) {

--- a/web/templates/files.html
+++ b/web/templates/files.html
@@ -117,7 +117,7 @@
 	<main class="p-8 max-lg:p-4">
 		<div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 mb-6">
 			<h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Your Files</h1>
-			
+
 			<!-- Storage Usage -->
 			<div class="relative rounded-full bg-gray-200 dark:bg-gray-700 px-4 py-2 overflow-hidden" title="Storage quota shown may be approximate. Server performs authoritative validation on uploads.">
 				<div class="absolute inset-0 bg-blue-400/30 dark:bg-blue-500/30 rounded-full transition-all duration-300" style="width: {{storagePercentage .User.StorageUsed .User.StorageQuota}}%;"></div>
@@ -217,7 +217,7 @@
 			<div class="flex flex-wrap gap-2">
 				{{range .Folders}}
 				<div class="flex items-center bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg border border-gray-200 dark:border-gray-600 hover:border-gray-300 dark:hover:border-gray-500 transition-all w-full sm:w-[200px]">
-						<a href="/files?folder={{if eq $.CurrentFolder "/"}}/{{.Name}}{{else}}{{$.CurrentFolder}}/{{.Name}}{{end}}" 
+						<a href="/files?folder={{if eq $.CurrentFolder "/"}}/{{.Name}}{{else}}{{$.CurrentFolder}}/{{.Name}}{{end}}"
 						   class="flex items-center gap-2 px-3 py-2 flex-1 min-w-0 cursor-pointer"
 						   title="{{.Name}}">
 							<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-yellow-500 dark:text-yellow-400 flex-shrink-0" aria-hidden="true">
@@ -227,7 +227,7 @@
 						</a>
 						<!-- Folder menu button -->
 						<div class="relative flex-shrink-0">
-							<button type="button" 
+							<button type="button"
 							        onclick="toggleItemMenu(event, 'folder-menu-{{.ID}}')"
 							        class="p-2 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-r-lg transition-colors"
 							        aria-label="Folder options">
@@ -284,140 +284,189 @@
 			{{if .Files}}
 			<!-- Files Section -->
 			<div>
-				<h2 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Files</h2>
-				<div class="overflow-x-auto">
-					<table class="w-full border-collapse">
-						<thead>
-							<tr class="bg-gray-50 dark:bg-gray-700">
-								<th class="text-left p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600">Name</th>
-								<th class="text-left p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 max-sm:hidden">Size</th>
-								<th class="text-left p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 max-md:hidden">Uploaded</th>
-								<th class="text-right p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 w-16"></th>
-							</tr>
-						</thead>
-						<tbody id="files-table-body">
-						{{range .Files}}
-						<tr data-file-id="{{.ID}}" data-upload-status="{{.UploadStatus}}" class="file-row hover:bg-gray-50 dark:hover:bg-gray-700/50 {{if eq .UploadStatus "completed"}}cursor-pointer{{end}} {{if ne .UploadStatus "completed"}}bg-yellow-50 dark:bg-yellow-900/10{{end}}" {{if eq .UploadStatus "completed"}}onclick="navigateToFile(event, {{.ID}})"{{end}}>
-							<td class="p-3 border-b border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 max-w-0">
-								<div class="flex items-center gap-2 min-w-0">
-									<span class="status-indicator">
-									{{if eq .UploadStatus "pending"}}
-									<svg class="animate-spin flex-shrink-0" width="16" height="16" style="min-width: 16px; max-width: 16px; min-height: 16px; max-height: 16px;" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-										<circle class="opacity-25" cx="12" cy="12" r="10" stroke="#ca8a04" stroke-width="4"></circle>
-										<path class="opacity-75" fill="#ca8a04" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-									</svg>
-									{{else if eq .UploadStatus "uploading"}}
-									<svg class="animate-spin flex-shrink-0" width="16" height="16" style="min-width: 16px; max-width: 16px; min-height: 16px; max-height: 16px;" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-										<circle class="opacity-25" cx="12" cy="12" r="10" stroke="#2563eb" stroke-width="4"></circle>
-										<path class="opacity-75" fill="#2563eb" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-									</svg>
-									{{end}}
-									</span>
-									<span class="status-label">
-									{{if eq .UploadStatus "pending"}}
-									<span class="text-yellow-600 dark:text-yellow-400 text-xs font-medium flex-shrink-0">Preparing...</span>
-									{{else if eq .UploadStatus "uploading"}}
-									<span class="text-blue-600 dark:text-blue-400 text-xs font-medium flex-shrink-0">Processing...</span>
-									{{end}}
-									</span>
-									<span class="truncate" title="{{.Filename}}">{{.Filename}}</span>
-								</div>
-							</td>
-							<td class="p-3 border-b border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 max-sm:hidden">{{formatBytes .FileSize}}</td>
-							<td class="p-3 border-b border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 max-md:hidden">{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
-							<td class="p-3 border-b border-gray-200 dark:border-gray-700 text-right">
-								<div class="relative inline-block">
-									<button type="button" 
-									        onclick="toggleItemMenu(event, 'file-menu-{{.ID}}')"
-									        class="p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
-									        aria-label="File options">
-										<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="text-gray-600 dark:text-gray-300">
-											<circle cx="12" cy="5" r="2"></circle>
-											<circle cx="12" cy="12" r="2"></circle>
-											<circle cx="12" cy="19" r="2"></circle>
-										</svg>
-									</button>
-									<!-- File dropdown menu -->
-									<div id="file-menu-{{.ID}}" class="hidden absolute right-0 top-full mt-1 w-36 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 z-50 py-1">
-										{{if eq .UploadStatus "completed"}}
-										<a href="/files/{{.ID}}" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-											<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-												<path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-												<circle cx="12" cy="12" r="3"></circle>
-											</svg>
-											View
-										</a>
-										<a href="/download/{{.ID}}" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-											<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-												<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-												<polyline points="7 10 12 15 17 10"></polyline>
-												<line x1="12" y1="15" x2="12" y2="3"></line>
-											</svg>
-											Download
-										</a>
-										<button type="button" data-item-type="file" data-item-name="{{.Filename}}" data-item-id="{{.ID}}" onclick="openRenameModal(this.dataset.itemType, this.dataset.itemName, this.dataset.itemId)" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left">
-											<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-												<path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-												<path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-											</svg>
-											Rename
-										</button>
-										<button type="button" data-item-name="{{.Filename}}" data-item-id="{{.ID}}" onclick="openMoveModal(this.dataset.itemName, this.dataset.itemId)" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left">
-											<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-												<path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
-												<polyline points="12 11 12 17"></polyline>
-												<polyline points="9 14 12 11 15 14"></polyline>
-											</svg>
-											Move
-										</button>
-										{{else}}
-										<span class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-400 dark:text-gray-500 cursor-not-allowed">
-											<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-												<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-												<polyline points="7 10 12 15 17 10"></polyline>
-												<line x1="12" y1="15" x2="12" y2="3"></line>
-											</svg>
-											Download
-										</span>
-										{{end}}
-										<div class="my-1 border-t border-gray-200 dark:border-gray-600"></div>
-										<form method="POST" action="/delete/{{.ID}}" onsubmit="return confirm('Are you sure you want to delete this file?');">
-											<button type="submit" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left">
-												<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-													<polyline points="3 6 5 6 21 6"></polyline>
-													<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-												</svg>
-												Delete
-											</button>
-										</form>
-									</div>
-								</div>
-							</td>
-						</tr>
-						{{end}}
-					</tbody>
-				</table>
-				</div>
+    <div class="flex items-center justify-between mb-4">
+        <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Files</h2>
 
-				<!-- Pagination -->
-				{{if gt .TotalPages 1}}
-				<div class="flex justify-between items-center mt-6 p-4 bg-gray-50 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">
-					{{if gt .Page 1}}
-						<a href="/files?folder={{.CurrentFolder}}&page={{.Page | add -1}}" class="bg-gray-900 dark:bg-gray-600 text-white px-4 py-2 rounded border border-gray-700 dark:border-gray-500 hover:bg-gray-700 dark:hover:bg-gray-500">← Previous</a>
-					{{else}}
-						<span class="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 opacity-40 cursor-not-allowed text-gray-500 dark:text-gray-400">← Previous</span>
-					{{end}}
+        <!-- Sort Dropdown -->
+        <select id="sort-select"
+                class="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="filename-asc"  {{if and (eq .SortField "filename") (eq .SortOrder "asc")}}selected{{end}}>Name (A-Z)</option>
+            <option value="filename-desc" {{if and (eq .SortField "filename") (eq .SortOrder "desc")}}selected{{end}}>Name (Z-A)</option>
+            <option value="file_size-desc" {{if and (eq .SortField "file_size") (eq .SortOrder "desc")}}selected{{end}}>Size (Largest first)</option>
+            <option value="file_size-asc"  {{if and (eq .SortField "file_size") (eq .SortOrder "asc")}}selected{{end}}>Size (Smallest first)</option>
+            <option value="created_at-desc" {{if and (eq .SortField "created_at") (eq .SortOrder "desc")}}selected{{end}}>Newest first</option>
+            <option value="created_at-asc"  {{if and (eq .SortField "created_at") (eq .SortOrder "asc")}}selected{{end}}>Oldest first</option>
+        </select>
+    </div>
 
-					<span class="text-gray-600 dark:text-gray-400 font-medium">Page {{.Page}} of {{.TotalPages}}</span>
+    <div class="overflow-x-auto">
+        <table class="w-full border-collapse">
+            <thead>
+                <tr class="bg-gray-50 dark:bg-gray-700">
+                    <th data-sort="filename"
+                        class="text-left p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
+                        Name
+                        <span class="sort-indicator ml-1 text-xs">
+                            {{if eq .SortField "filename"}}
+                                {{if eq .SortOrder "asc"}}↑{{else}}↓{{end}}
+                            {{end}}
+                        </span>
+                    </th>
+                    <th data-sort="file_size"
+                        class="text-left p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 max-sm:hidden cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
+                        Size
+                        <span class="sort-indicator ml-1 text-xs">
+                            {{if eq .SortField "file_size"}}
+                                {{if eq .SortOrder "asc"}}↑{{else}}↓{{end}}
+                            {{end}}
+                        </span>
+                    </th>
+                    <th data-sort="created_at"
+                        class="text-left p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 max-md:hidden cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors">
+                        Uploaded
+                        <span class="sort-indicator ml-1 text-xs">
+                            {{if eq .SortField "created_at"}}
+                                {{if eq .SortOrder "asc"}}↑{{else}}↓{{end}}
+                            {{end}}
+                        </span>
+                    </th>
+                    <th class="text-right p-3 text-gray-900 dark:text-gray-100 border-b border-gray-200 dark:border-gray-600 w-16"></th>
+                </tr>
+            </thead>
+            <tbody id="files-table-body">
+                {{range .Files}}
+                <tr data-file-id="{{.ID}}" data-upload-status="{{.UploadStatus}}"
+                    class="file-row hover:bg-gray-50 dark:hover:bg-gray-700/50
+                           {{if eq .UploadStatus "completed"}}cursor-pointer{{end}}
+                           {{if ne .UploadStatus "completed"}}bg-yellow-50 dark:bg-yellow-900/10{{end}}"
+                    {{if eq .UploadStatus "completed"}}onclick="navigateToFile(event, {{.ID}})"{{end}}>
 
-					{{if lt .Page .TotalPages}}
-						<a href="/files?folder={{.CurrentFolder}}&page={{.Page | add 1}}" class="bg-gray-900 dark:bg-gray-600 text-white px-4 py-2 rounded border border-gray-700 dark:border-gray-500 hover:bg-gray-700 dark:hover:bg-gray-500">Next →</a>
-					{{else}}
-						<span class="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 opacity-40 cursor-not-allowed text-gray-500 dark:text-gray-400">Next →</span>
-					{{end}}
-				</div>
-				{{end}}
-			</div>
+                    <td class="p-3 border-b border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 max-w-0">
+                        <div class="flex items-center gap-2 min-w-0">
+                            <span class="status-indicator">
+                                {{if eq .UploadStatus "pending"}}
+                                <svg class="animate-spin flex-shrink-0" width="16" height="16" style="min-width: 16px; max-width: 16px; min-height: 16px; max-height: 16px;" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="#ca8a04" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="#ca8a04" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                {{else if eq .UploadStatus "uploading"}}
+                                <svg class="animate-spin flex-shrink-0" width="16" height="16" style="min-width: 16px; max-width: 16px; min-height: 16px; max-height: 16px;" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="#2563eb" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="#2563eb" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                {{end}}
+                            </span>
+                            <span class="status-label">
+                                {{if eq .UploadStatus "pending"}}
+                                <span class="text-yellow-600 dark:text-yellow-400 text-xs font-medium flex-shrink-0">Preparing...</span>
+                                {{else if eq .UploadStatus "uploading"}}
+                                <span class="text-blue-600 dark:text-blue-400 text-xs font-medium flex-shrink-0">Processing...</span>
+                                {{end}}
+                            </span>
+                            <span class="truncate" title="{{.Filename}}">{{.Filename}}</span>
+                        </div>
+                    </td>
+                    <td class="p-3 border-b border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 max-sm:hidden">{{formatBytes .FileSize}}</td>
+                    <td class="p-3 border-b border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 max-md:hidden">{{.CreatedAt.Format "2006-01-02 15:04"}}</td>
+                    <td class="p-3 border-b border-gray-200 dark:border-gray-700 text-right">
+                        <div class="relative inline-block">
+                            <button type="button"
+                                    onclick="toggleItemMenu(event, 'file-menu-{{.ID}}')"
+                                    class="p-2 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors"
+                                    aria-label="File options">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" class="text-gray-600 dark:text-gray-300">
+                                    <circle cx="12" cy="5" r="2"></circle>
+                                    <circle cx="12" cy="12" r="2"></circle>
+                                    <circle cx="12" cy="19" r="2"></circle>
+                                </svg>
+                            </button>
+                            <!-- File dropdown menu -->
+                            <div id="file-menu-{{.ID}}" class="hidden absolute right-0 top-full mt-1 w-36 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-600 z-50 py-1">
+                                {{if eq .UploadStatus "completed"}}
+                                <a href="/files/{{.ID}}" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                                        <circle cx="12" cy="12" r="3"></circle>
+                                    </svg>
+                                    View
+                                </a>
+                                <a href="/download/{{.ID}}" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                        <polyline points="7 10 12 15 17 10"></polyline>
+                                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                                    </svg>
+                                    Download
+                                </a>
+                                <button type="button" data-item-type="file" data-item-name="{{.Filename}}" data-item-id="{{.ID}}"
+                                        onclick="openRenameModal(this.dataset.itemType, this.dataset.itemName, this.dataset.itemId)"
+                                        class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                                    </svg>
+                                    Rename
+                                </button>
+                                <button type="button" data-item-name="{{.Filename}}" data-item-id="{{.ID}}"
+                                        onclick="openMoveModal(this.dataset.itemName, this.dataset.itemId)"
+                                        class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                                        <polyline points="12 11 12 17"></polyline>
+                                        <polyline points="9 14 12 11 15 14"></polyline>
+                                    </svg>
+                                    Move
+                                </button>
+                                {{else}}
+                                <span class="w-full flex items-center gap-2 px-4 py-2 text-sm text-gray-400 dark:text-gray-500 cursor-not-allowed">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                                        <polyline points="7 10 12 15 17 10"></polyline>
+                                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                                    </svg>
+                                    Download
+                                </span>
+                                {{end}}
+                                <div class="my-1 border-t border-gray-200 dark:border-gray-600"></div>
+                                <form method="POST" action="/delete/{{.ID}}" onsubmit="return confirm('Are you sure you want to delete this file?');">
+                                    <button type="submit" class="w-full flex items-center gap-2 px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors text-left">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                            <polyline points="3 6 5 6 21 6"></polyline>
+                                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                        </svg>
+                                        Delete
+                                    </button>
+                                </form>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Pagination -->
+    {{if gt .TotalPages 1}}
+    <div class="flex justify-between items-center mt-6 p-4 bg-gray-50 dark:bg-gray-700 rounded border border-gray-200 dark:border-gray-600">
+        {{if gt .Page 1}}
+        <a href="/files?folder={{.CurrentFolder}}&page={{.Page | add -1}}&sort={{.SortField}}&order={{.SortOrder}}"
+           class="bg-gray-900 dark:bg-gray-600 text-white px-4 py-2 rounded border border-gray-700 dark:border-gray-500 hover:bg-gray-700 dark:hover:bg-gray-500">← Previous</a>
+        {{else}}
+        <span class="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 opacity-40 cursor-not-allowed text-gray-500 dark:text-gray-400">← Previous</span>
+        {{end}}
+
+        <span class="text-gray-600 dark:text-gray-400 font-medium">Page {{.Page}} of {{.TotalPages}}</span>
+
+        {{if lt .Page .TotalPages}}
+        <a href="/files?folder={{.CurrentFolder}}&page={{.Page | add 1}}&sort={{.SortField}}&order={{.SortOrder}}"
+           class="bg-gray-900 dark:bg-gray-600 text-white px-4 py-2 rounded border border-gray-700 dark:border-gray-500 hover:bg-gray-700 dark:hover:bg-gray-500">Next →</a>
+        {{else}}
+        <span class="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 opacity-40 cursor-not-allowed text-gray-500 dark:text-gray-400">Next →</span>
+        {{end}}
+    </div>
+    {{end}}
+</div>
 			{{end}}
 		{{else}}
 			<p class="text-gray-600 dark:text-gray-400">No files in this folder yet.</p>
@@ -519,7 +568,7 @@
 	// Update file row based on status event
 	function updateFileStatus(data) {
 		const row = document.querySelector(`tr[data-file-id="${data.id}"]`);
-		
+
 		// Handle failed uploads - show toast and auto-dismiss
 		if (data.upload_status === 'failed') {
 			showErrorToast(`Upload failed: ${data.filename}`, data.error_message || 'Check server logs for details.');
@@ -597,7 +646,7 @@
 		const toast = document.createElement('div');
 		// pointer-events: auto ensures the toast captures mouse events
 		toast.style.cssText = 'background-color: #dc2626; color: white; padding: 0.75rem 1rem; border-radius: 0.5rem; box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1); max-width: 24rem; display: flex; align-items: flex-start; gap: 0.75rem; position: relative; z-index: 99999; pointer-events: auto;';
-		
+
 		// Build toast content
 		const icon = document.createElement('div');
 		icon.style.cssText = 'flex-shrink: 0; margin-top: 0.125rem; pointer-events: auto;';
@@ -606,21 +655,21 @@
 			<line x1="15" y1="9" x2="9" y2="15"></line>
 			<line x1="9" y1="9" x2="15" y2="15"></line>
 		</svg>`;
-		
+
 		const content = document.createElement('div');
 		content.style.cssText = 'flex: 1; min-width: 0; pointer-events: auto;';
-		
+
 		const titleEl = document.createElement('div');
 		titleEl.style.cssText = 'font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;';
 		titleEl.textContent = title;
-		
+
 		const messageEl = document.createElement('div');
 		messageEl.style.cssText = 'font-size: 0.875rem; color: #fecaca; margin-top: 0.125rem;';
 		messageEl.textContent = message;
-		
+
 		content.appendChild(titleEl);
 		content.appendChild(messageEl);
-		
+
 		const closeBtn = document.createElement('button');
 		closeBtn.type = 'button';
 		closeBtn.style.cssText = 'flex-shrink: 0; color: #fecaca; background: none; border: none; cursor: pointer; padding: 0.25rem; display: flex; align-items: center; justify-content: center; pointer-events: auto;';
@@ -633,7 +682,7 @@
 			e.stopPropagation();
 			toast.remove();
 		});
-		
+
 		toast.appendChild(icon);
 		toast.appendChild(content);
 		toast.appendChild(closeBtn);
@@ -687,7 +736,7 @@
 					Move
 				</button>
 			`;
-			
+
 			// Replace the placeholder with all new menu items
 			while (menuItems.firstChild) {
 				downloadPlaceholder.parentNode.insertBefore(menuItems.firstChild, downloadPlaceholder);
@@ -771,7 +820,7 @@
 		createFolderModalTrap.activate();
 		document.getElementById('folder-name-input').focus();
 	}
-	
+
 	function closeCreateFolderModal() {
 		createFolderModalTrap.deactivate();
 		document.getElementById('create-folder-modal').classList.add('hidden');
@@ -809,7 +858,7 @@
 		newNameInput.value = currentName;
 		modal.classList.remove('hidden');
 		renameModalTrap.activate();
-		
+
 		// Select the filename without extension for files, or full name for folders
 		newNameInput.focus();
 		if (type === 'file') {
@@ -908,10 +957,10 @@
 		}
 
 		const allFolders = [];
-		
+
 		// Always include root (unless moving a top-level folder to root, which would be same location)
 		allFolders.push('/');
-		
+
 		// Add folders from the current view
 		{{range .Folders}}
 		{
@@ -926,7 +975,7 @@
 			}
 		}
 		{{end}}
-		
+
 		// Add parent folders from breadcrumbs
 		{{range .Breadcrumbs}}
 		{{if ne .Path "/"}}
@@ -939,13 +988,13 @@
 		}
 		{{end}}
 		{{end}}
-		
+
 		// Sort folders
 		allFolders.sort();
-		
+
 		// Clear existing options
 		selectElement.innerHTML = '';
-		
+
 		// Add options
 		allFolders.forEach(function(folder) {
 			const option = document.createElement('option');
@@ -968,10 +1017,10 @@
 		// Using jsStr template function to prevent XSS from special characters in folder names
 		const currentFolder = {{jsStr .CurrentFolder}};
 		const allFolders = [];
-		
+
 		// Always include root
 		allFolders.push('/');
-		
+
 		// Add folders from the current view
 		{{range .Folders}}
 		{{if eq $.CurrentFolder "/"}}
@@ -980,7 +1029,7 @@
 		allFolders.push({{printf "%s/%s" $.CurrentFolder .Name | jsStr}});
 		{{end}}
 		{{end}}
-		
+
 		// Add parent folders from breadcrumbs
 		{{range .Breadcrumbs}}
 		{{if ne .Path "/"}}
@@ -989,13 +1038,13 @@
 		}
 		{{end}}
 		{{end}}
-		
+
 		// Sort folders
 		allFolders.sort();
-		
+
 		// Clear existing options
 		selectElement.innerHTML = '';
-		
+
 		// Add options
 		allFolders.forEach(function(folder) {
 			const option = document.createElement('option');
@@ -1028,10 +1077,10 @@
 	function toggleItemMenu(event, menuId) {
 		event.preventDefault();
 		event.stopPropagation();
-		
+
 		const menu = document.getElementById(menuId);
 		const button = event.currentTarget;
-		
+
 		// Close any other open menu
 		if (currentOpenMenu && currentOpenMenu !== menu) {
 			currentOpenMenu.classList.add('hidden');
@@ -1040,18 +1089,18 @@
 			currentOpenMenu.style.left = '';
 			currentOpenMenu.style.right = '';
 		}
-		
+
 		// Toggle this menu
 		if (menu.classList.contains('hidden')) {
 			// Position the menu using fixed positioning to escape overflow containers
 			const rect = button.getBoundingClientRect();
 			menu.style.position = 'fixed';
 			menu.style.top = (rect.bottom + 4) + 'px';
-			
+
 			// Calculate right offset and check for overflow on small screens
 			const rightOffset = window.innerWidth - rect.right;
 			const menuWidth = 160; // Approximate menu width (w-40 = 10rem = 160px)
-			
+
 			// If menu would overflow left edge, switch to left alignment
 			if (rect.right - menuWidth < 0) {
 				menu.style.left = '4px';
@@ -1060,7 +1109,7 @@
 				menu.style.right = rightOffset + 'px';
 				menu.style.left = 'auto';
 			}
-			
+
 			menu.classList.remove('hidden');
 			currentOpenMenu = menu;
 		} else {
@@ -1084,7 +1133,7 @@
 			currentOpenMenu = null;
 		}
 	});
-	
+
 	// Close modal on Escape key
 	document.addEventListener('keydown', function(e) {
 		if (e.key === 'Escape') {
@@ -1198,17 +1247,17 @@
 				const currentTime = Date.now();
 				const elapsedSeconds = (currentTime - uploadStartTime) / 1000;
 				const uploadedBytes = progress.uploadedBytes;
-				
+
 				if (elapsedSeconds > 0.5) {
 					const speed = uploadedBytes / elapsedSeconds;
 					const remainingBytes = file.size - uploadedBytes;
 					const eta = speed > 0 ? remainingBytes / speed : 0;
 
 					document.getElementById('upload-speed').textContent = 'Speed: ' + formatBytes(speed) + '/s';
-					
+
 					if (eta > 0) {
-						const etaFormatted = eta < 60 
-							? Math.round(eta) + 's' 
+						const etaFormatted = eta < 60
+							? Math.round(eta) + 's'
 							: Math.floor(eta / 60) + 'm ' + Math.round(eta % 60) + 's';
 						document.getElementById('upload-eta').textContent = 'Time remaining: ' + etaFormatted;
 					}
@@ -1258,7 +1307,7 @@
 
 		// Create XHR for upload with progress tracking
 		const xhr = new XMLHttpRequest();
-		
+
 		// Variables for speed calculation with moving average
 		const startTime = Date.now();
 		let lastTime = startTime;
@@ -1281,25 +1330,25 @@
 				// Update speed every 500ms to smooth out fluctuations
 				if (timeDiff >= 0.5) {
 					const instantSpeed = bytesDiff / timeDiff; // bytes per second
-					
+
 					// Add to speed samples and maintain window size
 					speedSamples.push(instantSpeed);
 					if (speedSamples.length > maxSpeedSamples) {
 						speedSamples.shift();
 					}
-					
+
 					// Calculate moving average speed
 					const avgSpeed = speedSamples.reduce((a, b) => a + b, 0) / speedSamples.length;
-					
+
 					const remainingBytes = e.total - e.loaded;
 					const eta = avgSpeed > 0 ? remainingBytes / avgSpeed : 0; // seconds
 
 					// Update UI
 					document.getElementById('upload-speed').textContent = 'Speed: ' + formatBytes(avgSpeed) + '/s';
-					
+
 					if (eta > 0) {
-						const etaFormatted = eta < 60 
-							? Math.round(eta) + 's' 
+						const etaFormatted = eta < 60
+							? Math.round(eta) + 's'
 							: Math.floor(eta / 60) + 'm ' + Math.round(eta % 60) + 's';
 						document.getElementById('upload-eta').textContent = 'Time remaining: ' + etaFormatted;
 					} else {
@@ -1417,7 +1466,7 @@
 	document.body.addEventListener('drop', function(e) {
 		clearTimeout(dragOverlayTimeout);
 		hideDragOverlay();
-		
+
 		const files = e.dataTransfer.files;
 		if (files.length > 0) {
 			uploadFile(files[0]);
@@ -1431,6 +1480,55 @@
 		}
 	});
 
+	document.addEventListener('DOMContentLoaded', function() {
+    // Column header sorting
+    const sortableHeaders = document.querySelectorAll('th[data-sort]');
+    sortableHeaders.forEach(header => {
+        header.addEventListener('click', function() {
+            const field = this.getAttribute('data-sort');
+            toggleSort(field);
+        });
+    });
+
+    // Sort dropdown
+    const sortSelect = document.getElementById('sort-select');
+    if (sortSelect) {
+        sortSelect.addEventListener('change', function() {
+            applySort(this.value);
+        });
+    }
+});
+
+	// sorting functionality
+		function toggleSort(field){
+		  const url = new URL(window.location)
+				let currentField = url.searchParams.get('sort') || 'filename';
+				let currentOrder = url.searchParams.get('order') || 'asc';
+
+				if (currentField === field){
+		          currentOrder = currentOrder === 'asc' ? 'desc' : 'asc';
+				} else {
+		          currentOrder = (field === 'file_size' || field === 'created_at') ? 'desc' : 'asc';
+				}
+
+				url.searchParams.set('sort', field);
+				url.searchParams.set('order', currentOrder);
+				url.searchParams.set('page', 1);
+
+				window.location.href = url.toString();
+		}
+
+		function applySort(value){
+      const [field, order] = value.split('-');
+      const url = new URL(window.location);
+
+      url.searchParams.set('sort', field);
+      url.searchParams.set('order', order);
+      url.searchParams.set('page', '1');
+
+      window.location.href = url.toString();
+		}
+
 	// Initialize SSE if there are pending/uploading files on page load
 	{{if .Files}}
 	(function() {
@@ -1440,7 +1538,7 @@
 		hasPendingFiles = true;
 		{{end}}
 		{{end}}
-		
+
 		if (hasPendingFiles) {
 			initSSE();
 		}


### PR DESCRIPTION
…ence

- UI: clickable column headers for sorting with ?sort=size&order=desc URL params
- Backend: GORM Order() based on query params (filename, file_size, created_at only)
- Folders always pinned to top regardless of sort order
- Added comprehensive test coverage

## What does this PR do?

Adds sortable file listing with clickable column headers that persist sort state in URL query params (?sort=size&order=desc). Backend uses GORM Order() based on safe columns only (filename, file_size, created_at). Folders always appear at top regardless of sort direction.

## Why?

Improves UX by letting users sort files by name, size, or creation date. URL persistence enables bookmarking/sharing specific sort views and survives navigation.

## How to test

1. Run `make test` - all sorting test cases should pass
2. Start dev server: `make run`
3. Navigate to file listing page
4. Click column headers (filename/size/created_at) - verify:
   - Sort direction toggles (asc ↔ desc)
   - URL updates (?sort=size&order=desc)
   - Page refreshes with correct order
   - Folders stay pinned at top

## Checklist

- [x] Tests added/updated
- [x] `make test` passes
- [x] `make fmt` run (Go formatting)
- [ ] Documentation updated if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file sorting functionality with options for filename, file size, and creation date.
  * Sorting supports ascending and descending order (default ascending).
  * Implemented natural, case-insensitive filename sorting with numeric-aware ordering.
  * Added sorting UI controls including clickable column headers and a sort dropdown menu.
  * Sort selection persists across pagination.

* **Tests**
  * Added comprehensive test coverage for file sorting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->